### PR TITLE
feat: use same annotation for metadata and target files

### DIFF
--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -61,7 +61,7 @@ func TestCreateMetadataManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, layer := range l.Layers {
-		_, ok := layer.Annotations[tufRoleAnnotation]
+		_, ok := layer.Annotations[tufFileAnnotation]
 		if !ok {
 			t.Fatalf("missing annotations")
 		}


### PR DESCRIPTION
## Summary
* Uses same layer annotation for metadata and target files to simplify implementation in https://github.com/docker/image-signer-verifier/pull/122