### PR TITLE
feat: add signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ steps.app-token.outputs.token }}
       - name: Sign and push
-        uses: docker/image-signer-verifier/actions/sign@feat-add-image-signer-verifier-actions
+        uses: docker/image-signer-verifier/actions/sign@f01da364d0684acb8f6e80fc9f4f6d2d8eb3f360 # v0.4.8
         with:
           kms-key-arn: ${{ vars.AWS_KMS_ARN }}
           signed-image-path: "${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
## Summary
Adds signed attestations to `go-tuf-mirror` release workflow

requires https://github.com/docker/image-signer-verifier/pull/198
part of https://github.com/docker/secure-artifacts-team-issues/issues/132

### Tests
https://github.com/docker/go-tuf-mirror/actions/runs/9086077503/job/24970931713#step:11:41

### Example image
https://oci.dag.dev/?image=docker%2Fgo-tuf-mirror%3Asha-8ec850e

https://github.com/docker/secure-artifacts-team-issues/issues/132