### PR TITLE
fix: release workflow dbc multi-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: release
 on:
   release:
     types: [published]
-  pull_request:
 env:
   IMAGE_NAME: docker/go-tuf-mirror
   DOCKER_CONFIG: ${{ github.workspace }}/.docker
@@ -65,9 +64,9 @@ jobs:
           provenance: mode=max
           secrets: |
             GITHUB_TOKEN=${{ steps.app-token.outputs.token }}
-      # - name: Sign and push
-      #   uses: docker/image-signer-verifier/actions/sign@268a8c6b4084a1dddb60c7ea058e79f6bf784eeb # v0.5.5
-      #   with:
-      #     kms-key-arn: ${{ vars.AWS_KMS_ARN }}
-      #     signed-image-path: "${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
-      #     always-push: true
+      - name: Sign and push
+        uses: docker/image-signer-verifier/actions/sign@268a8c6b4084a1dddb60c7ea058e79f6bf784eeb # v0.5.5
+        with:
+          kms-key-arn: ${{ vars.AWS_KMS_ARN }}
+          signed-image-path: "${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+          always-push: true


### PR DESCRIPTION
## Summary
- updates release workflow to only build a single platform image

## Testing 
https://github.com/docker/go-tuf-mirror/actions/runs/9877072715/job/27277770223?pr=36