### PR TITLE
feat: use go-tuf-mirror 0.1.9

### DIFF
--- a/actions/metadata/action.yml
+++ b/actions/metadata/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: ""
 runs:
   using: docker
-  image: docker://docker/go-tuf-mirror@sha256:1c3d080f9989832c6205b1a8458dfcd8c07fb9f7b02727f2fe5334cdd9de08fb # v0.1.7
+  image: docker://docker/go-tuf-mirror@sha256:d4fb86ee5c94150be7adbcf6e82004f9baafe740de3c40b6e77d58bd639b5dfb # v0.1.9
   args:
     - metadata
     - ${{ inputs.flags }}

--- a/actions/targets/action.yml
+++ b/actions/targets/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: ""
 runs:
   using: docker
-  image: docker://docker/go-tuf-mirror@sha256:1c3d080f9989832c6205b1a8458dfcd8c07fb9f7b02727f2fe5334cdd9de08fb # v0.1.7
+  image: docker://docker/go-tuf-mirror@sha256:d4fb86ee5c94150be7adbcf6e82004f9baafe740de3c40b6e77d58bd639b5dfb # v0.1.9
   args:
     - targets
     - ${{ inputs.flags }}


### PR DESCRIPTION
## Summary
- updates actions to use go-tuf-mirror 0.1.9 for embedded production TUF root