### PR TITLE
fix: metadata needs targets for version checker

### DIFF
--- a/actions/metadata/action.yml
+++ b/actions/metadata/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: source metadata location
     default: https://docker.github.io/tuf/metadata
     required: true
+  targets:
+    description: source targets location
+    default: https://docker.github.io/tuf/targets
+    required: true
   destination:
     description: destination metadata location
     required: true
@@ -22,6 +26,7 @@ runs:
   args:
     - metadata
     - ${{ inputs.flags }}
+    - --targets=${{ inputs.targets }}
     - --source=${{ inputs.source }}
     - --destination=${{ inputs.destination }}
     - --tuf-root=${{ inputs.tuf-root }}


### PR DESCRIPTION
## Summary
- adding version checker to mirroring TUF client requires targets URL to download version-constraints file

## Fixes
Used default values since none were specified, causing:
https://github.com/docker/tuf/actions/runs/9893115656/job/27327454247#step:4:12

https://github.com/docker/attest/pull/87 updates defaults in attest to use production URLs (so that we discover these type of bugs in staging). I got most of them but missed these as they were a bit hidden under `/mirror/types.go`