### PR TITLE
chore: fix public secret access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_APP_PRIVATE_KEY }}
-          repositories: "attest,go-tuf-mirror"
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4.0.2
         with:
@@ -62,8 +55,6 @@ jobs:
           outputs: type=oci,tar=false,dest=./unsigned-image
           attests: type=sbom,generator=docker/scout-sbom-indexer:1
           provenance: mode=max
-          secrets: |
-            GITHUB_TOKEN=${{ steps.app-token.outputs.token }}
       - name: Sign and push
         uses: docker/image-signer-verifier/actions/sign@7e791e4c287d1976e457e6e1d1fa9d6f045ffdcc # v0.6.4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,7 @@ jobs:
         go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      GOPRIVATE: github.com/docker/attest
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.DOCKER_READ_APP_PRIVATE_KEY }}
-          repositories: "attest,go-tuf-mirror"
       - name: Set git to use LF
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
@@ -29,8 +20,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
-      - run: |
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
       - name: go test
         run: |
           go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 #   Copyright Docker go-tuf-mirror authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,39 +13,20 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-FROM --platform=linux/amd64 golang:1.22.6-alpine as deps
 
-WORKDIR /
-
-COPY go.* .
-
-# This block can be replaced by `RUN go mod download` when github.com/docker/attest is public
-RUN apk add --no-cache git
-ENV GOPRIVATE="github.com/docker/attest"
-RUN --mount=type=secret,id=GITHUB_TOKEN <<EOT
-  set -e
-  GITHUB_TOKEN=${GITHUB_TOKEN:-$(cat /run/secrets/GITHUB_TOKEN)}
-  if [ -n "$GITHUB_TOKEN" ]; then
-    echo "Setting GitHub access token"
-    git config --global "url.https://x-access-token:${GITHUB_TOKEN}@github.com.insteadof" "https://github.com"
-  fi
-  go mod download
-EOT
-
-FROM --platform=$BUILDPLATFORM golang:1.22.6-alpine as build
-
-WORKDIR /
-
-COPY --from=deps --link $GOPATH/pkg/mod $GOPATH/pkg/mod
-COPY . .
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS build
+WORKDIR /app
 
 ARG TARGETOS TARGETARCH TARGETVARIANT
 ARG VERSION="dev"
-ENV GOOS=$TARGETOS GOARCH=$TARGETARCH VARIANT=$TARGETVARIANT
+ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH VARIANT=$TARGETVARIANT
 
-RUN go build -ldflags "-X main.version=$VERSION" -o go-tuf-mirror;
+RUN --mount=type=bind,source=.,target=/app \
+  --mount=type=cache,target=$GOPATH/pkg/mod \
+  --mount=type=cache,target=/root/.cache/go-build \
+  go build -ldflags "-X main.version=$VERSION" -o /bin/go-tuf-mirror
 
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /go-tuf-mirror /usr/local/bin/go-tuf-mirror
-ENTRYPOINT ["/usr/local/bin/go-tuf-mirror"]
+COPY --from=build /bin/go-tuf-mirror /go-tuf-mirror
+ENTRYPOINT ["/go-tuf-mirror"]


### PR DESCRIPTION
Remove use of Docker Read App - we also no longer have access to the token now that this repo is public, and we don't need it anyway as the attest repo is also public.

Also rewrite the Dockerfile to simplify, fix cross-platform builds, and remove workaround for attest being private.